### PR TITLE
fix(ndc-cli) : update dockerfile

### DIFF
--- a/ndc-cli.dockerfile
+++ b/ndc-cli.dockerfile
@@ -14,6 +14,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:1.20-2
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 WORKDIR /app
+USER root
 
 # The "/app/output" directory is used by the NDC CLI "update" command as a bind-mount volume:
 #


### PR DESCRIPTION

I have tried running the MySQL and Phoenix connectors with the following versions:

- ndc-jvm-cli:v0.1.3
- ndc-jvm-cli:v0.1.0

It seems that the command mkdir -p /app/output && chmod 777 /app/output works, but the 'default' user does not have access to the ownership of the folder, which is set to user:group with UID:GID 1000 :1000.

Here is the log output when performing the introspect on the MySQL connector :

![image](https://github.com/user-attachments/assets/3694886d-50e5-45a5-9dbe-39adf330f4fa)

without USER root
![image](https://github.com/user-attachments/assets/36a12e6d-2338-464b-8af6-2fb864c5da5a)

with USER root
![image](https://github.com/user-attachments/assets/ca2d284c-6359-40f4-8dd8-a7816c0150e5)



