### PR TITLE
Correctly handle NativeQueries in Relationships

### DIFF
--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
@@ -30,23 +30,11 @@ object JsonQueryGenerator : BaseQueryGenerator() {
     fun queryRequestToSQLInternal(
         request: QueryRequest,
     ): SelectSelectStep<*> {
-        // If the QueryRequest "collection" references the name of a Native Query defined in the configuration.json,
-        // we need to prefix the generated query with a CTE named identically to the Native Query, containing the Native Query itself
-        val isNativeQuery = ConnectorConfiguration.Loader.config.nativeQueries.containsKey(request.collection)
-
-        return if (isNativeQuery) {
-            mkNativeQueryCTE(request).select(
-                jsonArrayAgg(
-                    buildJSONSelectionForQueryRequest(request)
-                )
+        return mkNativeQueryCTEs(request).select(
+            jsonArrayAgg(
+                buildJSONSelectionForQueryRequest(request)
             )
-        } else {
-            DSL.select(
-                jsonArrayAgg(
-                    buildJSONSelectionForQueryRequest(request)
-                )
-            )
-        }
+        )
     }
 
     fun buildJSONSelectionForQueryRequest(

--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
@@ -30,6 +30,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
     fun queryRequestToSQLInternal(
         request: QueryRequest,
     ): SelectSelectStep<*> {
+        // JOOQ is smart enough to not generate CTEs if there are no native queries
         return mkNativeQueryCTEs(request).select(
             jsonArrayAgg(
                 buildJSONSelectionForQueryRequest(request)

--- a/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
+++ b/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
@@ -89,6 +89,7 @@ abstract class BaseQueryGenerator : BaseGenerator {
         var nativeQueries = findAllNativeQueries(request)
 
         if (nativeQueries.isEmpty()) {
+            // JOOQ is smart enough to not generate CTEs if there are no native queries
             return DSL.with()
         }
 
@@ -113,9 +114,9 @@ abstract class BaseQueryGenerator : BaseGenerator {
             }
         }
 
-        var withStep = DSL.with()
+        val withStep = DSL.with()
         nativeQueries.forEach { collectionName ->
-            withStep = withStep.with(DSL.name(collectionName))
+            withStep.with(DSL.name(collectionName))
                 .`as`(DSL.resultQuery(
                     renderNativeQuerySQL(
                         config.nativeQueries[collectionName]!!,

--- a/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
+++ b/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
@@ -25,6 +25,108 @@ abstract class BaseQueryGenerator : BaseGenerator {
         throw NotImplementedError("Mutation not supported for this data source")
     }
 
+    protected fun findAllNativeQueries(request: QueryRequest): Set<String> {
+        val nativeQueries = mutableSetOf<String>()
+        val config = ConnectorConfiguration.Loader.config
+    
+        // Helper function to check if a collection is a native query
+        fun checkAndAddNativeQuery(collection: String) {
+            if (config.nativeQueries.containsKey(collection)) {
+                nativeQueries.add(collection)
+            }
+        }
+    
+        // Check main collection
+        checkAndAddNativeQuery(request.collection)
+    
+        // Check relationships
+        request.collection_relationships.values.forEach { rel ->
+            checkAndAddNativeQuery(rel.target_collection)
+        }
+    
+        // Recursive function to check predicates
+        fun checkPredicates(expression: Expression?) {
+            when (expression) {
+                is Expression.Exists -> {
+                    when (val collection = expression.in_collection) {
+                        is ExistsInCollection.Related -> {
+                            // Check related collection from relationship
+                            val rel = request.collection_relationships[collection.relationship]
+                                ?: error("Relationship ${collection.relationship} not found")
+                            checkAndAddNativeQuery(rel.target_collection)
+                        }
+                        is ExistsInCollection.Unrelated -> {
+                            checkAndAddNativeQuery(collection.collection)
+                        }
+                    }
+                    // Recursively check the predicate within exists
+                    checkPredicates(expression.predicate)
+                }
+                is Expression.And -> expression.expressions.forEach { checkPredicates(it) }
+                is Expression.Or -> expression.expressions.forEach { checkPredicates(it) }
+                is Expression.Not -> checkPredicates(expression.expression)
+                else -> {} // Other expression types don't reference collections
+            }
+        }
+    
+        // Check predicates in the main query
+        checkPredicates(request.query.predicate)
+    
+        // Check predicates in relationship fields
+        request.query.fields?.values?.forEach { field ->
+            if (field is IRField.RelationshipField) {
+                checkPredicates(field.query.predicate)
+            }
+        }
+    
+        return nativeQueries
+    }
+
+    fun mkNativeQueryCTEs(
+        request: QueryRequest
+    ): org.jooq.WithStep {
+        val config = ConnectorConfiguration.Loader.config
+        var nativeQueries = findAllNativeQueries(request)
+
+        if (nativeQueries.isEmpty()) {
+            return DSL.with()
+        }
+
+        fun renderNativeQuerySQL(
+            nativeQuery: NativeQueryInfo,
+            arguments: Map<String, Argument>
+        ): String {
+            val sql = nativeQuery.sql
+            val parts = sql.parts
+
+            return parts.joinToString("") { part ->
+                when (part) {
+                    is NativeQueryPart.Text -> part.value
+                    is NativeQueryPart.Parameter -> {
+                        val argument = arguments[part.value] ?: error("Argument ${part.value} not found")
+                        when (argument) {
+                            is Argument.Literal -> argument.value.toString()
+                            else -> error("Only literals are supported in Native Queries in this version")
+                        }
+                    }
+                }
+            }
+        }
+
+        var withStep = DSL.with()
+        nativeQueries.forEach { collectionName ->
+            withStep = withStep.with(DSL.name(collectionName))
+                .`as`(DSL.resultQuery(
+                    renderNativeQuerySQL(
+                        config.nativeQueries[collectionName]!!,
+                        request.arguments
+                    )
+                ))
+        }
+
+        return withStep
+    }
+
     fun mkNativeQueryCTE(
         request: QueryRequest
     ): org.jooq.WithStep {
@@ -446,9 +548,7 @@ abstract class BaseQueryGenerator : BaseGenerator {
                     e = where,
                     request
                 )
-            } ?: DSL.noCondition())).also {
-                println("Where conditions: $it")
-        }
+            } ?: DSL.noCondition()))
     }
 
     protected fun getDefaultAggregateJsonEntries(aggregates: Map<String, Aggregate>?): Field<*> {


### PR DESCRIPTION
I am not a jooq expert, but this works from my tests. Current problem is you can not use Native Queries in relationships and/or predicates. This fixes by finding all NativeQueries and generating CTE's if there are any.

```graphql
query MyQuery {
  profileInfos(where: {profileInfoUrls: {rowId: {_eq: 71}}}) {
    name
    id
    profileInfoUrls {
      url
      rowId
      tableId
    }
  }
}
```

```sql
with
  "ProfileInfoUrls" as (
    select * from urls where tableId = 7
  )
select json_arrayagg(json_object(key 'rows' value (
  select json_arrayagg(json_object(
    key 'name' value "name",
    key 'id' value "id",
    key 'profileInfoUrls' value coalesce(
      (
        select json_object(key 'rows' value (
          select json_arrayagg(json_object(
            key 'url' value "url",
            key 'rowId' value "rowId",
            key 'tableId' value "tableId"
          ))
          from (
            select "ProfileInfoUrls".*
            from "ProfileInfoUrls"
            where "profileInfos"."id" = "ProfileInfoUrls"."rowId"
          ) "ProfileInfoUrls"
        ))
      ),
      json_object(key 'rows' value json_array())
    )
  ))
  from (
    select "A.profileInfos".*
    from "A.profileInfos"
    where exists (
      select 1 "one"
      from "ProfileInfoUrls"
      where (
        "ProfileInfoUrls"."rowId" = 71
        and "A"."profileInfos"."id" = "ProfileInfoUrls"."rowId"
      )
    )
  ) "profileInfos"
)))
```