### PR TITLE
Accept jdbcUrl as an environment variable

### DIFF
--- a/ndc-cli/src/main/kotlin/io/hasura/cli/IConfigGenerator.kt
+++ b/ndc-cli/src/main/kotlin/io/hasura/cli/IConfigGenerator.kt
@@ -1,7 +1,8 @@
 package io.hasura.cli
 
 import io.hasura.ndc.common.ConnectorConfiguration
+import io.hasura.ndc.common.JdbcUrlConfig
 
 interface IConfigGenerator {
-    fun getConfig(jdbcUrl: String, schemas: List<String>): ConnectorConfiguration
+    fun getConfig(jdbcUrlConfig: JdbcUrlConfig, schemas: List<String>): ConnectorConfiguration
 }

--- a/ndc-connector-mysql/.hasura-connector/connector-metadata.yaml
+++ b/ndc-connector-mysql/.hasura-connector/connector-metadata.yaml
@@ -9,7 +9,7 @@ commands:
     docker run \
       -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH \
       -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/app/output \
-      ghcr.io/hasura/ndc-jvm-cli:v0.1.3 update $JDBC_URL \
+      ghcr.io/hasura/ndc-jvm-cli:v0.1.3 update \
         --database MYSQL \
         --schemas $JDBC_SCHEMAS \
         --outfile /app/output/configuration.json

--- a/ndc-connector-mysql/.hasura-connector/connector-metadata.yaml
+++ b/ndc-connector-mysql/.hasura-connector/connector-metadata.yaml
@@ -7,6 +7,7 @@ supportedEnvironmentVariables:
 commands:
   update: |
     docker run \
+      -e JDBC_URL \
       -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH \
       -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/app/output \
       ghcr.io/hasura/ndc-jvm-cli:v0.1.3 update \

--- a/ndc-connector-oracle/.hasura-connector/connector-metadata.yaml
+++ b/ndc-connector-oracle/.hasura-connector/connector-metadata.yaml
@@ -9,6 +9,7 @@ supportedEnvironmentVariables:
 commands:
   update: |
     docker run \
+      -e JDBC_URL \
       -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH \
       -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/app/output \
       ghcr.io/hasura/ndc-jvm-cli:v0.1.3 update \

--- a/ndc-connector-oracle/.hasura-connector/connector-metadata.yaml
+++ b/ndc-connector-oracle/.hasura-connector/connector-metadata.yaml
@@ -11,7 +11,7 @@ commands:
     docker run \
       -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH \
       -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/app/output \
-      ghcr.io/hasura/ndc-jvm-cli:v0.1.3 update $JDBC_URL \
+      ghcr.io/hasura/ndc-jvm-cli:v0.1.3 update \
         --database ORACLE \
         --schemas $JDBC_SCHEMAS \
         --outfile /app/output/configuration.json

--- a/ndc-connector-snowflake/.hasura-connector/connector-metadata.yaml
+++ b/ndc-connector-snowflake/.hasura-connector/connector-metadata.yaml
@@ -11,7 +11,7 @@ commands:
     docker run \
       -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH \
       -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/app/output \
-      ghcr.io/hasura/ndc-jvm-cli:v0.1.0 update $JDBC_URL \
+      ghcr.io/hasura/ndc-jvm-cli:v0.1.0 update \
         --database SNOWFLAKE \
         --schemas $JDBC_SCHEMAS \
         --outfile /app/output/configuration.json

--- a/ndc-connector-snowflake/.hasura-connector/connector-metadata.yaml
+++ b/ndc-connector-snowflake/.hasura-connector/connector-metadata.yaml
@@ -9,6 +9,7 @@ supportedEnvironmentVariables:
 commands:
   update: |
     docker run \
+      -e JDBC_URL \
       -e HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH \
       -v ${HASURA_PLUGIN_CONNECTOR_CONTEXT_PATH}:/app/output \
       ghcr.io/hasura/ndc-jvm-cli:v0.1.0 update \

--- a/ndc-ir/src/main/kotlin/io/hasura/ndc/common/ConnectorConfiguration.kt
+++ b/ndc-ir/src/main/kotlin/io/hasura/ndc/common/ConnectorConfiguration.kt
@@ -7,12 +7,13 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.annotation.JsonValue
 import java.io.File
 import java.nio.file.Path
 
 @JsonDeserialize(using = JdbcUrlConfigDeserializer::class)
 sealed class JdbcUrlConfig {
-    data class Literal(val value: String) : JdbcUrlConfig()
+    data class Literal(@JsonValue val value: String) : JdbcUrlConfig()
     data class EnvVar(val variable: String) : JdbcUrlConfig()
 }
 
@@ -28,7 +29,7 @@ class JdbcUrlConfigDeserializer : JsonDeserializer<JdbcUrlConfig>() {
 }
 
 data class ConnectorConfiguration(
-    val jdbcUrl: JdbcUrlConfig = JdbcUrlConfig.Literal(""),
+    val jdbcUrl: JdbcUrlConfig = JdbcUrlConfig.EnvVar("JDBC_URL"),
     val jdbcProperties: Map<String, Any> = emptyMap(),
     val schemas: List<String> = emptyList(),
     val tables: List<TableSchemaRow> = emptyList(),


### PR DESCRIPTION
This PR adds the ability to set in the config an environment variable for `jdbcUrl`. It is backwards compatible and also allows for a literal value.

TODO:
- [x] Check and update cli to default to using the environment variable in the config when writing it
- [x] Update changelog
- [x] Updating connector packaging