### PR TITLE
Update UnaryOp IR to use ColumnTarget

### DIFF
--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
@@ -1,16 +1,13 @@
 package io.hasura.mysql
 
-import io.hasura.ndc.common.ConnectorConfiguration
-import io.hasura.ndc.common.NDCScalar
 import io.hasura.ndc.ir.*
 import io.hasura.ndc.ir.Field.ColumnField
 import io.hasura.ndc.ir.Field as IRField
-import io.hasura.ndc.ir.Type
 import io.hasura.ndc.sqlgen.BaseQueryGenerator
+import io.hasura.ndc.sqlgen.DatabaseType
 import org.jooq.*
 import org.jooq.Field
 import org.jooq.impl.DSL
-import org.jooq.impl.SQLDataType
 
 
 object JsonQueryGenerator : BaseQueryGenerator() {
@@ -130,7 +127,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
                                                         request.collection,
                                                         field
                                                     )
-                                                    val castedField = castToSQLDataType(MYSQL, columnField, ndcScalar)
+                                                    val castedField = castToSQLDataType(DatabaseType.MYSQL, columnField, ndcScalar)
                                                     DSL.jsonEntry(
                                                         alias,
                                                         castedField
@@ -209,7 +206,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
     ): Set<Relationship> {
         return when (where) {
             is ExpressionOnColumn -> when (val column = where.column) {
-                is ComparisonColumn.Column -> {
+                is ComparisonTarget.Column -> {
                     column.path.fold(emptySet()) { acc, path ->
                         val relationship = collectionRelationships[path.relationship]
                             ?: error("Relationship ${path.relationship} not found")

--- a/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/JSONGenerator.kt
+++ b/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/JSONGenerator.kt
@@ -1,7 +1,6 @@
 package io.hasura.oracle
 
 import io.hasura.ndc.common.ConnectorConfiguration
-import io.hasura.ndc.common.NDCScalar
 import io.hasura.ndc.ir.*
 import io.hasura.ndc.ir.Type
 import io.hasura.ndc.ir.Field.ColumnField
@@ -187,7 +186,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
     ): Set<Relationship> {
         return when (where) {
             is ExpressionOnColumn -> when (val column = where.column) {
-                is ComparisonColumn.Column -> {
+                is ComparisonTarget.Column -> {
                     column.path.fold(emptySet()) { acc, path ->
                         val relationship = collectionRelationships[path.relationship]
                             ?: error("Relationship ${path.relationship} not found")

--- a/ndc-ir/src/main/kotlin/io/hasura/ndc/ir/Query.kt
+++ b/ndc-ir/src/main/kotlin/io/hasura/ndc/ir/Query.kt
@@ -22,16 +22,16 @@ data class QueryRequest(
 sealed interface Argument {
 
     @JsonTypeName("variable")
-    data class Variable(val name: String): Argument
+    data class Variable(val name: String) : Argument
 
     @JsonTypeName("literal")
-    data class Literal (val value: Any): Argument
+    data class Literal(val value: Any) : Argument
 
     @JsonTypeName("column")
-    data class Column (val name: String): Argument
+    data class Column(val name: String) : Argument
 }
 
-data class Relationship (
+data class Relationship(
     val column_mapping: Map<String, String>,
     val relationship_type: RelationshipType,
     val target_collection: String,
@@ -72,18 +72,25 @@ sealed interface Aggregate {
 enum class SingleColumnAggregateFunction {
     @JsonProperty("avg")
     AVG,
+
     @JsonProperty("sum")
     SUM,
+
     @JsonProperty("min")
     MIN,
+
     @JsonProperty("max")
     MAX,
+
     @JsonProperty("stddev_pop")
     STDDEV_POP,
+
     @JsonProperty("stddev_samp")
     STDDEV_SAMP,
+
     @JsonProperty("var_pop")
     VAR_POP,
+
     @JsonProperty("var_samp")
     VAR_SAMP
 }
@@ -106,7 +113,7 @@ sealed interface Field {
 sealed interface ComparisonValue {
 
     @JsonTypeName("column")
-    data class ColumnComp(val column: ComparisonColumn) : ComparisonValue
+    data class ColumnComp(val column: ComparisonTarget) : ComparisonValue
 
     @JsonTypeName("scalar")
     data class ScalarComp(val value: Any) : ComparisonValue
@@ -152,7 +159,7 @@ sealed interface OrderByTarget {
     ) : OrderByTarget
 }
 
-data class PathElement (
+data class PathElement(
     val relationship: String,
     val arguments: Map<String, Argument>,
     val predicate: Expression
@@ -164,20 +171,28 @@ data class PathElement (
 enum class ApplyBinaryComparisonOperator {
     @JsonProperty("_eq")
     EQ,
+
     @JsonProperty("_gt")
     GT,
+
     @JsonProperty("_lt")
     LT,
+
     @JsonProperty("_gte")
     GTE,
+
     @JsonProperty("_lte")
     LTE,
+
     @JsonProperty("_in")
     IN,
+
     @JsonProperty("_is_null")
     IS_NULL,
+
     @JsonProperty("_like")
     LIKE,
+
     @JsonProperty("_contains")
     CONTAINS,
 }
@@ -192,7 +207,7 @@ enum class ApplyUnaryComparisonOperator {
 // /////////////////////////////////////////////////////////////////////////
 
 interface ExpressionOnColumn {
-    val column: ComparisonColumn
+    val column: ComparisonTarget
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -210,13 +225,13 @@ sealed interface Expression {
     @JsonTypeName("unary_comparison_operator")
     data class ApplyUnaryComparison(
         val operator: ApplyUnaryComparisonOperator,
-        val column: String
+        val column: ComparisonTarget
     ) : Expression
 
     @JsonTypeName("binary_comparison_operator")
     data class ApplyBinaryComparison(
         val operator: ApplyBinaryComparisonOperator,
-        override val column: ComparisonColumn,
+        override val column: ComparisonTarget,
         val value: ComparisonValue
     ) : Expression, ExpressionOnColumn
 
@@ -229,15 +244,22 @@ sealed interface Expression {
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-sealed interface ComparisonColumn {
+sealed interface ComparisonTarget {
 
     val name: String
 
     @JsonTypeName("column")
-    data class Column(override val name: String, val path: List<PathElement>) : ComparisonColumn
+    data class Column(
+        override val name: String,
+        val path: List<PathElement>,
+        val field_path: List<String>? = null
+    ) : ComparisonTarget
 
     @JsonTypeName("root_collection_column")
-    data class RootCollectionColumn(override val name: String) : ComparisonColumn
+    data class RootCollectionColumn(
+        override val name: String,
+        val field_path: List<String>? = null
+    ) : ComparisonTarget
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -247,7 +269,7 @@ sealed interface ExistsInCollection {
     data class Related(
         val relationship: String,
         val arguments: Map<String, Argument> = emptyMap()
-        ) : ExistsInCollection
+    ) : ExistsInCollection
 
     @JsonTypeName("unrelated")
     data class Unrelated(
@@ -257,7 +279,7 @@ sealed interface ExistsInCollection {
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class RowSet (
+data class RowSet(
     val aggregates: Map<String, Any>? = null,
     val rows: List<Map<String, Any>>? = null
 )

--- a/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
+++ b/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
@@ -276,8 +276,8 @@ abstract class BaseQueryGenerator : BaseGenerator {
         expression: Expression? = request.query.predicate,
         seenRelations: MutableSet<String> = mutableSetOf()
     ) {
-        fun addForColumn(column: ComparisonColumn) {
-            if (column is ComparisonColumn.Column) {
+        fun addForColumn(column: ComparisonTarget) {
+            if (column is ComparisonTarget.Column) {
                 column.path.forEach {
                     if (!seenRelations.contains(it.relationship)) {
                         val r = request.collection_relationships[it.relationship]!!


### PR DESCRIPTION
Update IR to use `ComparisonTarget` for `ApplyUnaryComparison` per latest v0.16 spec

Example query used to test (MySQL Chinook `track` where `composer` is `null`)
```http
POST http://localhost:8080/query
Content-Type: application/json

{
  "collection": "Chinook.Track",
  "query": {
    "limit": 3,
    "fields": {
      "TrackId": {
        "type": "column",
        "column": "TrackId",
        "fields": null
      },
      "Name": {
        "type": "column",
        "column": "Name",
        "fields": null
      },
      "Composer": {
        "type": "column",
        "column": "Composer",
        "fields": null
      }
    },
    "predicate": {
      "type": "unary_comparison_operator",
      "operator": "is_null",
      "column": {
        "type": "column",
        "name": "Composer",
        "path": []
      },
      "value": {
        "type": "scalar",
        "value": null
      }
    }
  }
}
```

Results:
```http
HTTP/1.1 200 OK
content-length: 178
Content-Type: application/json;charset=UTF-8

[
  {
    "rows": [
      {
        "Name": "Balls to the Wall",
        "TrackId": 2,
        "Composer": null
      },
      {
        "Name": "Desafinado",
        "TrackId": 63,
        "Composer": null
      },
      {
        "Name": "Garota De Ipanema",
        "TrackId": 64,
        "Composer": null
      }
    ]
  }
]
```