### PR TITLE
Add alias to derived table expressions to prevent self-join conflicts

### DIFF
--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
@@ -48,8 +48,9 @@ object JsonQueryGenerator : BaseQueryGenerator() {
 
         val baseSelection = DSL.select(
             DSL.table(DSL.name(request.collection)).asterisk()
-        ).select(getSelectOrderFields(request))
-            .from(
+        ).select(
+            getSelectOrderFields(request)
+        ).from(
             if (request.query.predicate == null) {
                 DSL.table(DSL.name(request.collection))
             } else {
@@ -77,8 +78,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
             }
         ).apply {
             addJoinsRequiredForOrderByFields(this, request)
-        }
-            .apply {
+        }.apply {
             if (request.query.predicate != null) {
                 where(getWhereConditions(request))
             }


### PR DESCRIPTION
Prevent conflicts with self-referential relationships like `employee.employee_id <-> employee.reports_to` when both the base table itself and the relationship to it are asked for in a single query.
