### PR TITLE
removed token verification from /health endpoint

### DIFF
--- a/ndc-app/src/main/kotlin/io/hasura/ndc/app/application/Filters.kt
+++ b/ndc-app/src/main/kotlin/io/hasura/ndc/app/application/Filters.kt
@@ -24,6 +24,8 @@ class Filters {
 
     @ServerRequestFilter
     fun tokenFilter(ctx: ContainerRequestContext): Response? {
+        if(ctx.uriInfo.path.startsWith("/health")) return null
+
         val secret = System.getenv("HASURA_SERVICE_TOKEN_SECRET")
         if (secret.isNullOrEmpty()) {
             logger.warn("Environment variable HASURA_SERVICE_TOKEN_SECRET not set. Token validation is bypassed.")


### PR DESCRIPTION
Quick fix to removed bearer token verification from `/health` endpoint, as required by the `ndc-spec` (in particular, for introspection)