### PR TITLE
Remove "count" aggregate fn, type, return empty/null rows explicitly for ndc-test

### DIFF
--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/JSONGenerator.kt
@@ -109,24 +109,9 @@ object JsonQueryGenerator : BaseQueryGenerator() {
             DSL.name(getTableName(request.collection))
         )
 
-        val isAggregatesOnlyQuery = request.query.fields.isNullOrEmpty() && !request.query.aggregates.isNullOrEmpty()
-
         return DSL.jsonObject(
             buildList {
-                if (request.query.fields.isNullOrEmpty()) {
-                    add(
-                        DSL.jsonEntry(
-                            "rows",
-                            // If this is an only-aggregates query, the engine expects: { "rows": null }
-                            if (isAggregatesOnlyQuery)
-                                DSL.inline(null as? String?)
-                            else
-                            // Otherwise, it expects: { "rows": [] }
-                                DSL.jsonArray()
-                        )
-                    )
-                }
-                else {
+                if (!request.query.fields.isNullOrEmpty()) {
                     add(
                         DSL.jsonEntry(
                             "rows",
@@ -198,15 +183,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
                         )
                     )
                 }
-                if (request.query.aggregates.isNullOrEmpty()) {
-                    add(
-                        DSL.jsonEntry(
-                            "aggregates",
-                            DSL.inline(null as? String?)
-                        )
-                    )
-                }
-                else {
+                if (!request.query.aggregates.isNullOrEmpty()) {
                     add(
                         DSL.jsonEntry(
                             "aggregates",
@@ -273,6 +250,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
                 SingleColumnAggregateFunction.AVG -> DSL.avg(col)
                 SingleColumnAggregateFunction.MAX -> DSL.max(col)
                 SingleColumnAggregateFunction.MIN -> DSL.min(col)
+                SingleColumnAggregateFunction.COUNT -> DSL.count(col)
                 SingleColumnAggregateFunction.SUM -> DSL.sum(col)
                 SingleColumnAggregateFunction.STDDEV_POP -> DSL.stddevPop(col)
                 SingleColumnAggregateFunction.STDDEV_SAMP -> DSL.stddevSamp(col)

--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/MySQLDataConnectorService.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/MySQLDataConnectorService.kt
@@ -26,7 +26,7 @@ class MySQLDataConnectorService @Inject constructor(
 ) {
 
     override val capabilitiesResponse = CapabilitiesResponse(
-        version = "0.1.2",
+        version = "0.1.6",
         capabilities = Capabilities(
             query = QueryCapabilities(
                 aggregates = mapOf(),

--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/MySQLJDBCSchemaGenerator.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/MySQLJDBCSchemaGenerator.kt
@@ -140,24 +140,24 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
                 )
             ),
-//            NDCScalar.BIGINTEGER.name to ScalarType(
-//                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
-//                comparison_operators = mapOf(
-//                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_eq" to ComparisonOperatorDefinition.Equal,
-//                    "_in" to ComparisonOperatorDefinition.In
-//                ),
-//                aggregate_functions = mapOf(
-//                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-//                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name))
-//                )
-//            ),
+            NDCScalar.BIGINTEGER.name to ScalarType(
+                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
+                comparison_operators = mapOf(
+                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_eq" to ComparisonOperatorDefinition.Equal,
+                    "_in" to ComparisonOperatorDefinition.In
+                ),
+                aggregate_functions = mapOf(
+                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name))
+                )
+            ),
             NDCScalar.BIGDECIMAL.name to ScalarType(
                 representation = ScalarRepresentation(NDCScalar.BIGDECIMAL),
                 comparison_operators = mapOf(

--- a/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/MySQLJDBCSchemaGenerator.kt
+++ b/ndc-connector-mysql/src/main/kotlin/io/hasura/mysql/MySQLJDBCSchemaGenerator.kt
@@ -45,7 +45,7 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT8.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT8.name))
                 )
@@ -63,7 +63,7 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT16.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT16.name))
                 )
@@ -81,7 +81,7 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT32.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT32.name))
                 )
@@ -99,7 +99,7 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name))
                 )
@@ -117,7 +117,7 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name))
                 )
@@ -135,29 +135,29 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
                 )
             ),
-            NDCScalar.BIGINTEGER.name to ScalarType(
-                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
-                comparison_operators = mapOf(
-                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_eq" to ComparisonOperatorDefinition.Equal,
-                    "_in" to ComparisonOperatorDefinition.In
-                ),
-                aggregate_functions = mapOf(
-                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name))
-                )
-            ),
+//            NDCScalar.BIGINTEGER.name to ScalarType(
+//                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
+//                comparison_operators = mapOf(
+//                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_eq" to ComparisonOperatorDefinition.Equal,
+//                    "_in" to ComparisonOperatorDefinition.In
+//                ),
+//                aggregate_functions = mapOf(
+//                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+//                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name))
+//                )
+//            ),
             NDCScalar.BIGDECIMAL.name to ScalarType(
                 representation = ScalarRepresentation(NDCScalar.BIGDECIMAL),
                 comparison_operators = mapOf(
@@ -171,7 +171,7 @@ object MySQLJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name))
                 )

--- a/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/JSONGenerator.kt
+++ b/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/JSONGenerator.kt
@@ -282,6 +282,7 @@ object JsonQueryGenerator : BaseQueryGenerator() {
                 SingleColumnAggregateFunction.AVG -> DSL.avg(col)
                 SingleColumnAggregateFunction.MAX -> DSL.max(col)
                 SingleColumnAggregateFunction.MIN -> DSL.min(col)
+                SingleColumnAggregateFunction.COUNT -> DSL.count(col)
                 SingleColumnAggregateFunction.SUM -> DSL.sum(col)
                 SingleColumnAggregateFunction.STDDEV_POP -> DSL.stddevPop(col)
                 SingleColumnAggregateFunction.STDDEV_SAMP -> DSL.stddevSamp(col)

--- a/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/OracleDataConnectorService.kt
+++ b/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/OracleDataConnectorService.kt
@@ -27,7 +27,7 @@ class OracleDataConnectorService @Inject constructor(
 ) {
 
     override val capabilitiesResponse = CapabilitiesResponse(
-        version = "0.1.2",
+        version = "0.1.6",
         capabilities = Capabilities(
             query = QueryCapabilities(
                 aggregates = mapOf(),

--- a/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/OracleJDBCSchemaGenerator.kt
+++ b/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/OracleJDBCSchemaGenerator.kt
@@ -45,7 +45,7 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT8.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT8.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -67,7 +67,7 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT16.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT16.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -89,7 +89,7 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT32.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT32.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -111,7 +111,7 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -133,7 +133,7 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -155,7 +155,7 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -164,28 +164,28 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                     "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
                 )
             ),
-            NDCScalar.BIGINTEGER.name to ScalarType(
-                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
-                comparison_operators = mapOf(
-                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_eq" to ComparisonOperatorDefinition.Equal,
-                    "_in" to ComparisonOperatorDefinition.In
-                ),
-                aggregate_functions = mapOf(
-                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
-                )
-            ),
+//            NDCScalar.BIGINTEGER.name to ScalarType(
+//                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
+//                comparison_operators = mapOf(
+//                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_eq" to ComparisonOperatorDefinition.Equal,
+//                    "_in" to ComparisonOperatorDefinition.In
+//                ),
+//                aggregate_functions = mapOf(
+//                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+//                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
+//                )
+//            ),
             NDCScalar.BIGDECIMAL.name to ScalarType(
                 representation = ScalarRepresentation(NDCScalar.BIGDECIMAL),
                 comparison_operators = mapOf(
@@ -199,7 +199,7 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),

--- a/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/OracleJDBCSchemaGenerator.kt
+++ b/ndc-connector-oracle/src/main/kotlin/io/hasura/oracle/OracleJDBCSchemaGenerator.kt
@@ -164,28 +164,28 @@ object OracleJDBCSchemaGenerator : JDBCSchemaGenerator() {
                     "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
                 )
             ),
-//            NDCScalar.BIGINTEGER.name to ScalarType(
-//                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
-//                comparison_operators = mapOf(
-//                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_eq" to ComparisonOperatorDefinition.Equal,
-//                    "_in" to ComparisonOperatorDefinition.In
-//                ),
-//                aggregate_functions = mapOf(
-//                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-//                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
-//                )
-//            ),
+            NDCScalar.BIGINTEGER.name to ScalarType(
+                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
+                comparison_operators = mapOf(
+                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_eq" to ComparisonOperatorDefinition.Equal,
+                    "_in" to ComparisonOperatorDefinition.In
+                ),
+                aggregate_functions = mapOf(
+                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
+                )
+            ),
             NDCScalar.BIGDECIMAL.name to ScalarType(
                 representation = ScalarRepresentation(NDCScalar.BIGDECIMAL),
                 comparison_operators = mapOf(

--- a/ndc-connector-snowflake/src/main/kotlin/io/hasura/snowflake/SnowflakeDataConnectorService.kt
+++ b/ndc-connector-snowflake/src/main/kotlin/io/hasura/snowflake/SnowflakeDataConnectorService.kt
@@ -28,7 +28,7 @@ class SnowflakeDataConnectorService @Inject constructor(
 ) {
 
     override val capabilitiesResponse = CapabilitiesResponse(
-        version = "0.1.2",
+        version = "0.1.6",
         capabilities = Capabilities(
             query = QueryCapabilities(
                 aggregates = mapOf(),

--- a/ndc-connector-trino/src/main/kotlin/io/hasura/trino/TrinoDataConnectorService.kt
+++ b/ndc-connector-trino/src/main/kotlin/io/hasura/trino/TrinoDataConnectorService.kt
@@ -26,7 +26,7 @@ class TrinoDataConnectorService @Inject constructor(
 ) {
 
     override val capabilitiesResponse = CapabilitiesResponse(
-        version = "0.1.2",
+        version = "0.1.6",
         capabilities = Capabilities(
             query = QueryCapabilities(
                 aggregates = mapOf(),

--- a/ndc-connector-trino/src/main/kotlin/io/hasura/trino/TrinoJDBCSchemaGenerator.kt
+++ b/ndc-connector-trino/src/main/kotlin/io/hasura/trino/TrinoJDBCSchemaGenerator.kt
@@ -164,28 +164,28 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                     "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
                 )
             ),
-//            NDCScalar.BIGINTEGER.name to ScalarType(
-//                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
-//                comparison_operators = mapOf(
-//                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "_eq" to ComparisonOperatorDefinition.Equal,
-//                    "_in" to ComparisonOperatorDefinition.In
-//                ),
-//                aggregate_functions = mapOf(
-//                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-//                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-//                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-//                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
-//                )
-//            ),
+            NDCScalar.BIGINTEGER.name to ScalarType(
+                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
+                comparison_operators = mapOf(
+                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "_eq" to ComparisonOperatorDefinition.Equal,
+                    "_in" to ComparisonOperatorDefinition.In
+                ),
+                aggregate_functions = mapOf(
+                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
+                )
+            ),
             NDCScalar.BIGDECIMAL.name to ScalarType(
                 representation = ScalarRepresentation(NDCScalar.BIGDECIMAL),
                 comparison_operators = mapOf(

--- a/ndc-connector-trino/src/main/kotlin/io/hasura/trino/TrinoJDBCSchemaGenerator.kt
+++ b/ndc-connector-trino/src/main/kotlin/io/hasura/trino/TrinoJDBCSchemaGenerator.kt
@@ -45,7 +45,7 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT8.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT8.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -67,7 +67,7 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT16.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT16.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -89,7 +89,7 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT32.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT32.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -111,7 +111,7 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -133,7 +133,7 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT32.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -155,7 +155,7 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
@@ -164,28 +164,28 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                     "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
                 )
             ),
-            NDCScalar.BIGINTEGER.name to ScalarType(
-                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
-                comparison_operators = mapOf(
-                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "_eq" to ComparisonOperatorDefinition.Equal,
-                    "_in" to ComparisonOperatorDefinition.In
-                ),
-                aggregate_functions = mapOf(
-                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
-                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
-                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
-                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
-                )
-            ),
+//            NDCScalar.BIGINTEGER.name to ScalarType(
+//                representation = ScalarRepresentation(NDCScalar.BIGINTEGER),
+//                comparison_operators = mapOf(
+//                    "_gt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_lt" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_gte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_lte" to ComparisonOperatorDefinition.Custom(argument_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "_eq" to ComparisonOperatorDefinition.Equal,
+//                    "_in" to ComparisonOperatorDefinition.In
+//                ),
+//                aggregate_functions = mapOf(
+//                    "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+//                    "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGINTEGER.name)),
+//                    "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "stddev_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "var_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
+//                    "var_samp" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name))
+//                )
+//            ),
             NDCScalar.BIGDECIMAL.name to ScalarType(
                 representation = ScalarRepresentation(NDCScalar.BIGDECIMAL),
                 comparison_operators = mapOf(
@@ -199,7 +199,7 @@ object TrinoJDBCSchemaGenerator : JDBCSchemaGenerator() {
                 aggregate_functions = mapOf(
                     "avg" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),
                     "sum" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
-                    "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
+                    // "count" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.INT64.name)),
                     "min" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
                     "max" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.BIGDECIMAL.name)),
                     "stddev_pop" to AggregateFunctionDefinition(result_type = Type.Named(NDCScalar.FLOAT64.name)),

--- a/ndc-ir/src/main/kotlin/io/hasura/ndc/ir/Query.kt
+++ b/ndc-ir/src/main/kotlin/io/hasura/ndc/ir/Query.kt
@@ -76,6 +76,9 @@ enum class SingleColumnAggregateFunction {
     @JsonProperty("sum")
     SUM,
 
+    @JsonProperty("count")
+    COUNT,
+
     @JsonProperty("min")
     MIN,
 

--- a/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
+++ b/ndc-sqlgen/src/main/kotlin/io/hasura/ndc/sqlgen/BaseQueryGenerator.kt
@@ -398,6 +398,7 @@ abstract class BaseQueryGenerator : BaseGenerator {
                 when (field.function) {
                     SingleColumnAggregateFunction.AVG -> DSL.avg(jooqField)
                     SingleColumnAggregateFunction.SUM -> DSL.sum(jooqField)
+                    SingleColumnAggregateFunction.COUNT -> DSL.count(jooqField)
                     SingleColumnAggregateFunction.MIN -> DSL.min(jooqField)
                     SingleColumnAggregateFunction.MAX -> DSL.max(jooqField)
                     SingleColumnAggregateFunction.STDDEV_POP -> DSL.stddevPop(jooqField)


### PR DESCRIPTION
This fixes the following errors when using the `ndc-test` binary from `v0.1.6`:

```
[3] single_column
  in Query
  in Chinook.Album
  in Aggregate queries
  in single_column
Details: error communicating with the connector: error in response: status code 500 Internal Server Error

Uncaught exception: com.fasterxml.jackson.databind.exc.InvalidFormatException:
Cannot deserialize value of type `io.hasura.ndc.ir.SingleColumnAggregateFunction` from String "count": not one of the values accepted for Enum class: [avg, max, var_pop, sum, stddev_samp, min, stddev_pop, var_samp]
 
at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 247] (through reference chain: io.hasura.ndc.ir.QueryRequest["query"]->io.hasura.ndc.ir.Query["aggregates"]->java.util.LinkedHashMap["ArtistId_count_2717"]->io.hasura.ndc.ir.Aggregate$SingleColumn["function"])
```

```
[1] Predicates
  in Query
  in Chinook.Album
  in Simple queries
  in Predicates
Details: expected non-null rows in RowSet
```



