### PR TITLE
Trino CLI: multi-catalog support

### DIFF
--- a/ndc-cli/src/main/kotlin/io/hasura/cli/TrinoConfigGenerator.kt
+++ b/ndc-cli/src/main/kotlin/io/hasura/cli/TrinoConfigGenerator.kt
@@ -8,7 +8,8 @@ import io.hasura.ndc.common.TableType
 import org.jooq.impl.DSL
 
 fun debug(message: String) {
-    if (System.getenv("PROMPTQL_DEBUG") == "true") {
+    val logLevel = System.getenv("HASURA_LOG_LEVEL") ?: "info"
+    if (logLevel.lowercase() == "debug") {
         println(message)
     }
 }


### PR DESCRIPTION
This PR adds support for introspecting multiple catalogs in Trino.

It is a breaking change, as it now mandates the `--schemas` flag and that the JDBC url not contain either a `catalog` or `schema` entry.

Now, introspection command takes the form:
```
update jdbc:trino://localhost:8080?user=trino \
--database=TRINO \
--schemas=tpcds,tpch.sf1,tpch.sf100
```

This will introspect `tpcds.*`, and `tpch.sf1 + sf100`:
```sql
Introspecting database...
No specific schemas for catalog tpcds, including all schemas
Filtering schemas for catalog tpch: [sf1, sf100]
Executing query to fetch table and column information...
    SELECT table_catalog, table_schema, table_name, column_name, data_type, is_nullable
    FROM tpcds.information_schema.columns
    UNION ALL
    SELECT table_catalog, table_schema, table_name, column_name, data_type, is_nullable
    FROM tpch.information_schema.columns
    WHERE table_schema IN ('sf1','sf100')
```