### PR TITLE
OTEL: Add "internal.visibility" = "user" to spans

### DIFF
--- a/ndc-app/src/main/kotlin/io/hasura/ndc/app/application/OpenTelemetryConfiguration.kt
+++ b/ndc-app/src/main/kotlin/io/hasura/ndc/app/application/OpenTelemetryConfiguration.kt
@@ -1,0 +1,28 @@
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import jakarta.inject.Singleton
+
+@ApplicationScoped
+class OpenTelemetryConfiguration {
+
+    @Produces
+    @Singleton
+    fun customSpanProcessor(): SpanProcessor = DefaultAttributeSpanProcessor()
+
+    private class DefaultAttributeSpanProcessor : SpanProcessor {
+        override fun onStart(context: Context, span: ReadWriteSpan) {
+            span.setAttribute("internal.visibility", "user")
+        }
+
+        override fun onEnd(span: ReadableSpan) {
+            // no-op
+        }
+
+        override fun isStartRequired(): Boolean = true
+        override fun isEndRequired(): Boolean = false
+    }
+}

--- a/ndc-app/src/main/resources/application.properties
+++ b/ndc-app/src/main/resources/application.properties
@@ -5,7 +5,6 @@ quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{pa
 quarkus.live-reload.instrumentation=true
 #
 quarkus.datasource.devservices.enabled=false
-quarkus.opentelemetry.enabled=true
 
 quarkus.index-dependency.ndc-ir.group-id=io.hasura
 quarkus.index-dependency.ndc-ir.artifact-id=ndc-ir


### PR DESCRIPTION
Set `internal.visibility = user` so that spans are visible in Hasura/PromptQL Console:

<img width="2556" height="1318" alt="image" src="https://github.com/user-attachments/assets/4ed9b890-34e6-4e9f-98bc-71b7b2dd4e63" />
